### PR TITLE
Remove multiple periods after traveler name

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -59,7 +59,8 @@ def get_lines(file, year, include_table_header=True, print_debug_lines=False):
             continue
 
 def clean_cell(value, default=''):
-    """Removes trailing periods and strips leading and trailing whitespace."""
+    """Removes repeated periods, trailing periods and strips leading and trailing whitespace."""
+    value = re.sub('\.\.','', value).strip()
     value = re.sub(r'\.+$','', value).strip()
     if value == '':
         return default
@@ -91,6 +92,7 @@ def get_columns(line, year):
     # Get the country
     country = clean_cell(line[63:88])
     items.append(country)
+
     return items
 
 def write_header_line(out_file):
@@ -100,7 +102,7 @@ def write_header_line(out_file):
              'country',
              'table_header',
              'source_file']
-    print(','.join(['"' + c + '"' for c in items]),file=out_file)
+    print(','.join(['"' + c + '"' for c in items]), file=out_file)
 
 def process_a_file(file_name):
     """Processes a file returns rows through yield to make it iterable."""
@@ -133,4 +135,3 @@ if __name__ == "__main__":
     if len(sys.argv) != 3:
         print_help()
     write_many_to_one(sys.argv[1], sys.argv[2])
-        

--- a/scraper.py
+++ b/scraper.py
@@ -60,8 +60,7 @@ def get_lines(file, year, include_table_header=True, print_debug_lines=False):
 
 def clean_cell(value, default=''):
     """Removes repeated periods, trailing periods and strips leading and trailing whitespace."""
-    value = re.sub('\.\.','', value).strip()
-    value = re.sub(r'\.+$','', value).strip()
+    value = re.sub(r'\.+$','', value.strip()).strip()
     if value == '':
         return default
     else:


### PR DESCRIPTION
Some of the traveler names had multiple periods after them; I've added a line to the `clean_cell` method that removes these.